### PR TITLE
Add ambient lighting screen

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -318,3 +318,11 @@ App.tsx            # 專案入口
 - **命名規範標準化**：採用 `screen*` 前綴命名（如 `home*`、`music*`、`vehicle*`、`climate*`、`ai*`）
 - **樣式可維護性提升**：100+ 樣式定義統一管理，便於主題切換和響應式調整
 - **清理冗餘代碼**：移除所有螢幕文件中的 `StyleSheet.create()` 區塊和本地樣式引用
+
+### \ud83d\udcc5 2025-07-22
+
+#### \ud83c\udf08 \u65b0\u589e AmbientLightScreen
+
+- \u5f37\u5316\u8f09\u5165\u300cAmbientLightScreen\u300d\uff0c\u7528\u6237\u53ef\u8abf\u63a7\u8eca\u5167\u6c1b\u570d\u71c8\u8272\u8abf\u8207\u4eae\u5ea6
+- HomeScreen \u65b0\u589e palette \u6309\u9215\uff0c\u53ef\u6253\u958b\u8a72 overlay
+- `layoutStyles` \u65b0\u589e `ambient*` \u6a23\u5f0f\u5b9a\u7fa9

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An in-vehicle UI demo built from scratch using React Native and TypeScript, desi
 - **Home Screen**
 
   - Full-screen interactive map with a black bezel for a car-like experience.
-  - Bottom control bar with icons for Vehicle Info, Climate, Music, and AI Assistant.
+  - Bottom control bar with icons for Vehicle Info, Climate, Ambient Lighting, Music, and AI Assistant.
   - Overlay panels (cards) instead of traditional navigation—smooth slide-in/out animations and tap-to-close behavior.
   - Default vehicle status card modeled after Tesla’s center display (speed, warnings, quick actions).
 
@@ -31,6 +31,10 @@ An in-vehicle UI demo built from scratch using React Native and TypeScript, desi
 - **Vehicle Info**
 
   - Live warning indicators (engine, oil pressure, battery, TPMS, etc.) via WebSocket notifications.
+
+- **Ambient Lighting**
+
+  - Fun color orb lets you adjust cabin light hue and intensity.
 
 - **Music Player**
 
@@ -64,7 +68,7 @@ assets/                # Icons & images
 src/
   components/          # Reusable UI components (ControlButton, BottomBarButton, FloatingStatusBar, MapView)
   hooks/               # Custom hooks (useClimateSettings, useHomeClimateSettings, etc.)
-  screens/             # Screen components (HomeScreen, ClimateScreen, VehicleInfoScreen, MusicScreen, AIAssistantScreen)
+  screens/             # Screen components (HomeScreen, ClimateScreen, VehicleInfoScreen, AmbientLightScreen, MusicScreen, AIAssistantScreen)
   styles/              # Shared style definitions (commonStyles)
   types/               # Type declarations
 App.tsx                # Entry point for the React Native app

--- a/src/screens/AmbientLightScreen.tsx
+++ b/src/screens/AmbientLightScreen.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { View, Text, StyleSheet, Platform } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useResponsiveStyles } from "../hooks/useResponsiveStyles";
+import { layoutStyles } from "../styles/layoutStyles";
+import Orb from "../components/Orb";
+
+// Slider fallback for web
+const Slider =
+  Platform.OS === "web"
+    ? ({
+        value,
+        onValueChange,
+        minimumValue = 0,
+        maximumValue = 1,
+        step = 0.01,
+        style,
+        ...rest
+      }: any) => (
+        <input
+          max={maximumValue}
+          min={minimumValue}
+          step={step}
+          style={StyleSheet.flatten(style)}
+          type="range"
+          value={value}
+          onChange={(e) => onValueChange(parseFloat(e.target.value))}
+          {...rest}
+        />
+      )
+    : require("@react-native-community/slider").default;
+
+const AmbientLightScreen: React.FC = () => {
+  const responsiveScale = useResponsiveStyles();
+  const [hue, setHue] = useState(180);
+  const [intensity, setIntensity] = useState(0.5);
+
+  return (
+    <SafeAreaView style={layoutStyles.ambientContainer}>
+      <View style={layoutStyles.ambientOrbContainer}>
+        <Orb hoverIntensity={intensity} hue={hue} />
+      </View>
+      <View style={layoutStyles.ambientControlGroup}>
+        <Text
+          style={[
+            layoutStyles.ambientLabel,
+            { fontSize: responsiveScale.mediumFontSize },
+          ]}
+        >
+          Hue
+        </Text>
+        <Slider
+          maximumValue={360}
+          minimumValue={0}
+          step={1}
+          style={layoutStyles.ambientSlider}
+          value={hue}
+          onValueChange={(v: number) => setHue(v)}
+        />
+      </View>
+      <View style={layoutStyles.ambientControlGroup}>
+        <Text
+          style={[
+            layoutStyles.ambientLabel,
+            { fontSize: responsiveScale.mediumFontSize },
+          ]}
+        >
+          Intensity
+        </Text>
+        <Slider
+          maximumValue={1}
+          minimumValue={0}
+          step={0.01}
+          style={layoutStyles.ambientSlider}
+          value={intensity}
+          onValueChange={(v: number) => setIntensity(v)}
+        />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default AmbientLightScreen;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -25,6 +25,7 @@ import { warningIconMap } from "./VehicleInfoScreen";
 import VehicleInfoScreen from "./VehicleInfoScreen";
 import MusicScreen from "./MusicScreen";
 import ClimateScreen from "./ClimateScreen";
+import AmbientLightScreen from "./AmbientLightScreen";
 
 const HomeScreen: React.FC = () => {
   const responsiveScale = useResponsiveStyles();
@@ -38,7 +39,7 @@ const HomeScreen: React.FC = () => {
   const { sendMessage: sendBroadcastMessage } = useBroadcastMessage();
 
   const [activeOverlay, setActiveOverlay] = React.useState<
-    "vehicle" | "music" | "climate" | null
+    "vehicle" | "music" | "climate" | "ambient" | null
   >(null);
   const [fullScreenOverlay, setFullScreenOverlay] =
     React.useState<boolean>(false);
@@ -293,7 +294,9 @@ const HomeScreen: React.FC = () => {
   const { icon: voiceIcon, color: voiceColor } = getVoiceIconAndColor();
 
   // Helper to toggle overlay selection
-  const handleOverlayPress = (type: "vehicle" | "music" | "climate") => {
+  const handleOverlayPress = (
+    type: "vehicle" | "music" | "climate" | "ambient",
+  ) => {
     if (activeOverlay === type) {
       setActiveOverlay(null);
     } else {
@@ -389,6 +392,7 @@ const HomeScreen: React.FC = () => {
           )}
           {activeOverlay === "music" && <MusicScreen />}
           {activeOverlay === "climate" && <ClimateScreen />}
+          {activeOverlay === "ambient" && <AmbientLightScreen />}
         </View>
       </Animated.View>
 
@@ -483,6 +487,17 @@ const HomeScreen: React.FC = () => {
           <MaterialIcons
             color="#fff"
             name="music-note"
+            size={responsiveScale.largeIconSize}
+          />
+        </TouchableOpacity>
+        {/* Ambient light icon */}
+        <TouchableOpacity
+          style={layoutStyles.homeBottomBarBtn}
+          onPress={() => handleOverlayPress("ambient")}
+        >
+          <MaterialCommunityIcons
+            color="#fff"
+            name="palette"
             size={responsiveScale.largeIconSize}
           />
         </TouchableOpacity>

--- a/src/styles/layoutStyles.ts
+++ b/src/styles/layoutStyles.ts
@@ -533,4 +533,27 @@ export const layoutStyles = StyleSheet.create({
     borderRadius: 10,
     width: "30%",
   },
+  // === AmbientLightScreen styles ===
+  ambientContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  ambientOrbContainer: {
+    width: 200,
+    height: 200,
+    marginBottom: 30,
+  },
+  ambientControlGroup: {
+    width: "100%",
+    marginBottom: 20,
+  },
+  ambientLabel: {
+    color: "#fff",
+    marginBottom: 10,
+  },
+  ambientSlider: {
+    width: "100%",
+  },
 });


### PR DESCRIPTION
## Summary
- add AmbientLightScreen for cabin mood light control
- integrate new screen with HomeScreen bottom bar
- define ambient styles
- document new feature
- note update in copilot instructions

## Testing
- `npm run format`
- `npm run lint`
- `pytest`
- `pre-commit run -a` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8754f31c83218b0b73522e9747dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增环境氛围灯控制界面，可调节车内氛围灯的颜色与亮度。
  * 首页底部控制栏新增氛围灯按钮，点击可打开氛围灯调节面板。

* **样式**
  * 增加了氛围灯相关的统一界面样式，提升视觉一致性。

* **文档**
  * 更新了README，介绍氛围灯新功能及其操作方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->